### PR TITLE
Removed 4 samples that were promoted to Cascades-Samples

### DIFF
--- a/InvokeClient/README.md
+++ b/InvokeClient/README.md
@@ -1,2 +1,0 @@
-This same has moved to the [Cascades-Samples](http://github.com/blackberry/Cascades-Samples)
-Repository

--- a/InvokeTarget1/README.md
+++ b/InvokeTarget1/README.md
@@ -1,2 +1,0 @@
-This same has moved to the [Cascades-Samples](http://github.com/blackberry/Cascades-Samples)
-Repository

--- a/InvokeTarget2/README.md
+++ b/InvokeTarget2/README.md
@@ -1,2 +1,0 @@
-This same has moved to the [Cascades-Samples](http://github.com/blackberry/Cascades-Samples)
-Repository

--- a/LocationDiagnostics/README.md
+++ b/LocationDiagnostics/README.md
@@ -1,2 +1,0 @@
-This same has moved to the [Cascades-Samples](http://github.com/blackberry/Cascades-Samples)
-Repository


### PR DESCRIPTION
InvokeClient, InvokeTarget1, InvokeTarget2 and LocationDiagnostics

We had removed the actual content a while ago and only left the README files but this is actually confusing to the casual observer, and the catalog has the official location anyhow (plus the history has the change if you want to be really careful)
