### PR TITLE
Fixed incorrect freeing of memory in NfcTool 

### DIFF
--- a/NfcTool/README.md
+++ b/NfcTool/README.md
@@ -20,6 +20,9 @@ the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 **Release History**
 
+* **V5.0.2** 
+	* Improper freeing of memory fixed
+
 * **V5.0.1** 
 	* NDEF data included in Tag Details screens
 	* UI text simplified

--- a/NfcTool/bar-descriptor.xml
+++ b/NfcTool/bar-descriptor.xml
@@ -35,7 +35,7 @@
     <!-- A string value of the format <0-999>.<0-999>.<0-999> that represents application version which can be used to check for application upgrade. 
          Values can also be 1-part or 2-part. It is not necessary to have a 3-part value.
          An updated version of application must have a versionNumber value higher than the previous version. Required. -->
-    <versionNumber>5.0.1</versionNumber>
+    <versionNumber>5.0.2</versionNumber>
     <buildIdFile>buildnum</buildIdFile>
 
     <!-- Fourth digit segment of the package version. First three segments are taken from the 

--- a/NfcTool/src/NfcWorker.cpp
+++ b/NfcTool/src/NfcWorker.cpp
@@ -910,8 +910,8 @@ void NfcWorker::doIso7816Test(const QVariant &aid, bool select_only, const QVari
 			QString responseAsHex = QString::fromAscii(responseData.toHex());
 			emit message(QString("APDU response: %1").arg(responseAsHex));
 		}
+		free(result);
 	}
-	free(result);
 
 	// Close the channel
 	if (NFC_RESULT_SUCCESS != nfc_se_channel_close_channel(seChannel)) {

--- a/NfcTool/src/Settings.cpp
+++ b/NfcTool/src/Settings.cpp
@@ -16,7 +16,7 @@
 
 // General constants
 
-const char* Settings::AppVersion = "5.0.1";
+const char* Settings::AppVersion = "5.0.2";
 const char* Settings::DOMAIN = "my.domain.com";
 const char* Settings::TYPE = "myrecordtype";
 const char* Settings::CONTENT = "content";


### PR DESCRIPTION
New application version is 5.0.2
