### PR TITLE
Bug fix release. Fixed PPSE AID value (removed final 0x00). Added note t...

### DIFF
--- a/NfcTool/README.md
+++ b/NfcTool/README.md
@@ -20,6 +20,10 @@ the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 **Release History**
 
+* **V5.1.1** 
+  * Fixed PPSE AID value (removed final 0x00). Added note to apdu.qml pages to indicate that users must decide whether or not to specify Le=0x00 or not as this requirement varies from card to card.
+  * Fixed incorrect QML id reference in qpdu.qml
+
 * **V5.1.0** 
   * Added LLCP function
   * Fixed some memory management issues

--- a/NfcTool/assets/720x720/apdu.qml
+++ b/NfcTool/assets/720x720/apdu.qml
@@ -110,7 +110,7 @@ Page {
 		                    checked: _apdu._ppse
 		                    onCheckedChanged: {
 		                        if (checked) {
-		                            txf_aid.text = "325041592E5359532E444446303100"
+		                            txf_aid.text = "325041592E5359532E4444463031"
 		                        } else {
 		                            txf_aid.text = ""
 		                        }
@@ -245,6 +245,15 @@ Page {
 		                    enabled: ! cbx_select_only.checked
 		                }
 		            }
+                    Label {
+                        text: "Note: For a zero length response, some cards require Le=0x00 whilsts others require it to be completely absent from the APDU"
+                        multiline: true
+                        textStyle {
+                            base: SystemDefaults.TextStyles.SmallText
+                            fontStyle: FontStyle.Italic
+                            color: Color.LightGray
+                        }
+                    }
 		            Label {
 		                text: "Command data:"
 		                textStyle {
@@ -275,7 +284,7 @@ Page {
             ActionBar.placement: ActionBarPlacement.OnBar
             onTriggered: {
                 console.log("Issue APDU Triggered");
-                apdu.apduRequested();
+                apdu_menu.apduRequested();
             }
         }
     ]

--- a/NfcTool/assets/apdu.qml
+++ b/NfcTool/assets/apdu.qml
@@ -104,7 +104,7 @@ Page {
                     checked: _apdu._ppse
                     onCheckedChanged: {
                         if (checked) {
-                            txf_aid.text = "325041592E5359532E444446303100"
+                            txf_aid.text = "325041592E5359532E4444463031"
                         } else {
                             txf_aid.text = ""
                         }
@@ -240,6 +240,15 @@ Page {
                 }
             }
             Label {
+                text: "Note: For a zero length response, some cards require Le=0x00 whilsts others require it to be completely absent from the APDU"
+                multiline: true
+                textStyle {
+                    base: SystemDefaults.TextStyles.SmallText
+                    fontStyle: FontStyle.Italic
+                    color: Color.LightGray
+                }
+            }
+            Label {
                 text: "Command data:"
                 textStyle {
                     base: SystemDefaults.TextStyles.BodyText
@@ -266,7 +275,7 @@ Page {
             ActionBar.placement: ActionBarPlacement.OnBar
             onTriggered: {
                 console.log("Issue APDU Triggered");
-                apdu.apduRequested();
+                apdu_menu.apduRequested();
             }
         }
     ]

--- a/NfcTool/src/Settings.cpp
+++ b/NfcTool/src/Settings.cpp
@@ -16,7 +16,7 @@
 
 // General constants
 
-const char* Settings::AppVersion = "5.1.0";
+const char* Settings::AppVersion = "5.1.1";
 const char* Settings::DOMAIN = "my.domain.com";
 const char* Settings::TYPE = "myrecordtype";
 const char* Settings::CONTENT = "content";


### PR DESCRIPTION
...o

apdu.qml pages to indicate that users must decide whether or not to
specify Le=0x00 or not as this requirement varies from card to card. Fixed
incorrect QML id reference in qpdu.qml.
