### PR TITLE
Now builds without warnings about deprecated API in 10.3.0

### DIFF
--- a/WheresMyBeacon/README.md
+++ b/WheresMyBeacon/README.md
@@ -19,6 +19,7 @@ the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 * **V1.0.0** - Initial release
 * **V1.0.1** - Added an "About" page and improved layout of iBeacon(TM) information in ListView.
 * **V2.0.0** - Added ability to associate a friendly name with a beacon to aid identification. Added beacon configuration screen to allow SensorTag beacon attributes to be modified. 
+* **V2.0.1** - Minor change to deal with warnings about an API deprecated in 10.3.0 when building against the 10.3.0 SDK and above. No functional changes, hence no replacement pre-built signed BAR file.
 
 **Known Issues**
 

--- a/WheresMyBeacon/assets/AboutSheet.qml
+++ b/WheresMyBeacon/assets/AboutSheet.qml
@@ -81,7 +81,7 @@ Sheet {
             verticalAlignment: VerticalAlignment.Fill
             Label {
                 id: lblHeading_version
-                text: qsTr("V2.0.0")
+                text: qsTr("V2.0.1")
                 verticalAlignment: VerticalAlignment.Center
                 horizontalAlignment: HorizontalAlignment.Center
             }

--- a/WheresMyBeacon/bar-descriptor.xml
+++ b/WheresMyBeacon/bar-descriptor.xml
@@ -52,11 +52,11 @@
     <!-- A string value of the format <0-999>.<0-999>.<0-999> that represents application version which can be used to check for application upgrade.
          Values can also be 1-part or 2-part. It is not necessary to have a 3-part value.
          An updated version of application must have a versionNumber value higher than the previous version. Required. -->
-    <versionNumber>2.0.0</versionNumber>
+    <versionNumber>2.0.1</versionNumber>
 
     <!-- Fourth digit segment of the package version. First three segments are taken from the
          <versionNumber> element.  Must be an integer from 0 to 2^16-1 -->
-    <buildId>2</buildId>
+    <buildId>1</buildId>
 
     <!-- A string value (such as "v1", "2.5", or "Alpha 1") that represents the version of the application, as it should be shown to users. Optional. -->
     <!-- <versionLabel></versionLabel> -->

--- a/WheresMyBeacon/src/applicationui.hpp
+++ b/WheresMyBeacon/src/applicationui.hpp
@@ -28,6 +28,7 @@
 #include <btapi/btle.h>
 #include <errno.h>
 #include <bb/cascades/GroupDataModel>
+#include <bbndk.h>
 
 using namespace bb::cascades;
 


### PR DESCRIPTION
10.3.0 deprecated a an API which resulted in build warnings
when built on SDK 10.3.0
