### PR TITLE
Updates for 10.3.1.

### DIFF
--- a/Community3/assets/forumThread.qml
+++ b/Community3/assets/forumThread.qml
@@ -99,17 +99,17 @@ Page {
             ]
             
             function itemType(data, indexPath) {
-                if (indexPath == 0)
+                if (threadProvider.hasSolution && indexPath == 0)
+                {
+                    return "solved";
+                }
+                else if (indexPath == 0)
                 {
                     return "first";
                 }
                 else if (threadProvider.isSolution(data.id[".data"]))
                 {
                     return "solution";
-                }
-                else if (threadProvider.hasSolution && indexPath == 0)
-                {
-                    return "solved";
                 }
                 else 
                 {

--- a/Community3/assets/items/ForumFloatedThreadListItem.qml
+++ b/Community3/assets/items/ForumFloatedThreadListItem.qml
@@ -23,7 +23,6 @@ import bb.cascades 1.2
 //CustomListItem for displaying Floated Threads.
 
 CustomListItem {
-    preferredHeight: 265 
     dividerVisible: true
     highlightAppearance: HighlightAppearance.Frame
     Container {

--- a/Community3/assets/items/ForumRecentThreadListItem.qml
+++ b/Community3/assets/items/ForumRecentThreadListItem.qml
@@ -23,7 +23,6 @@ import com.msohm.BoardProperties 1.0
 //CustomListItem for displaying Threads.
 
 CustomListItem {
-    preferredHeight: 310 
     dividerVisible: true
     highlightAppearance: HighlightAppearance.Frame
     Container {

--- a/Community3/assets/items/ForumThreadFirstItem.qml
+++ b/Community3/assets/items/ForumThreadFirstItem.qml
@@ -22,8 +22,6 @@ import com.msohm.URLProvider 1.0
 
 CustomListItem {
     id: forumThreadItem
-    preferredHeight: 5000 //Set to a large number which should accomodate most posts.  It's shrunk after the post content size is calculated.
-    preferredWidth: 5000 //Large number so wide posts fit in the WebView.
     dividerVisible: true
     highlightAppearance: HighlightAppearance.Frame
     Container {
@@ -91,7 +89,7 @@ CustomListItem {
             WebView {
                 id: bodyWebView
                 //This allows for horizontal scrolling with the content zoomed to the desired level.
-                html: "<html><head><script language=\"javascript\" type=\"text/javascript\"> function getHeight() { var theHeight = document.getElementById(\"heightProvider\").offsetHeight; return theHeight;} </script></head><body><div id=\"heightProvider\">" + ListItemData.body[".data"] + "</div></body></html>"
+                html: "<html><body>" + ListItemData.body[".data"] + "</body></html>"
                 settings.zoomToFitEnabled: false
                 settings.background: Color.Transparent
                 settings.viewport: { "initial-scale" : 1.0, "width" : "device-width"}
@@ -107,19 +105,6 @@ CustomListItem {
                     }
                 }
                 
-                //Get the height of the forum content after it's loaded.
-                onLoadingChanged: {
-                    if (loadRequest.status == WebLoadStatus.Succeeded) {
-                        bodyWebView.evaluateJavaScript("getHeight();", JavaScriptWorld.Normal);
-                    }
-                }
-                
-                //Reset the CustomListItem's height based on the post content.
-                //Take ScrollView scale into consideration so we don't have extra white space.
-                //ScrollView will zoom out for wide content.
-                onJavaScriptResult: {
-                    forumThreadItem.preferredHeight = 380 + (result * bodyWebView.settings.devicePixelRatio);
-                }
                 settings.webInspectorEnabled: false
 
             }

--- a/Community3/assets/items/ForumThreadFirstSolvedItem.qml
+++ b/Community3/assets/items/ForumThreadFirstSolvedItem.qml
@@ -22,8 +22,6 @@ import com.msohm.URLProvider 1.0
 
 CustomListItem {
     id: forumThreadItem
-    preferredHeight: 5000 //Set to a large number which should accomodate most posts.  It's shrunk after the post content size is calculated.
-    preferredWidth: 5000 //Large number so wide posts fit in the WebView.
     dividerVisible: true
     highlightAppearance: HighlightAppearance.Frame
     Container {
@@ -89,7 +87,7 @@ CustomListItem {
             WebView {
                 id: bodyWebView
                 //This allows for horizontal scrolling with the content zoomed to the desired level.
-                html: "<html><head><script language=\"javascript\" type=\"text/javascript\"> function getHeight() { var theHeight = document.getElementById(\"heightProvider\").offsetHeight; return theHeight;} </script></head><body><div id=\"heightProvider\">" + ListItemData.body[".data"] + "</div></body></html>"
+                html: "<html><body>" + ListItemData.body[".data"] + "</body></html>"
                 settings.zoomToFitEnabled: false
                 settings.background: Color.Transparent
                 settings.viewport: { "initial-scale" : 1.0, "width" : "device-width"}
@@ -105,19 +103,6 @@ CustomListItem {
                     }
                 }
 
-                //Get the height of the forum content after it's loaded.
-                onLoadingChanged: {
-                    if (loadRequest.status == WebLoadStatus.Succeeded) {
-                        bodyWebView.evaluateJavaScript("getHeight();", JavaScriptWorld.Normal);
-                    }
-                }
-
-                //Reset the CustomListItem's height based on the post content.
-                //Take ScrollView scale into consideration so we don't have extra white space.
-                //ScrollView will zoom out for wide content.
-                onJavaScriptResult: {
-                    forumThreadItem.preferredHeight = 380 + (result * bodyWebView.settings.devicePixelRatio);
-                }
                 settings.webInspectorEnabled: false
 
             }

--- a/Community3/assets/items/ForumThreadItem.qml
+++ b/Community3/assets/items/ForumThreadItem.qml
@@ -22,8 +22,6 @@ import com.msohm.URLProvider 1.0
 
 CustomListItem {
     id: forumThreadItem
-    preferredHeight: 5000 //Set to a large number which should accomodate most posts.  It's shrunk after the post content size is calculated.
-    preferredWidth: 5000 //Large number so wide posts fit in the WebView.
     dividerVisible: true
     highlightAppearance: HighlightAppearance.Frame
     Container {
@@ -89,7 +87,7 @@ CustomListItem {
             WebView {
                 id: bodyWebView
                 //This allows for horizontal scrolling with the content zoomed to the desired level.
-                html: "<html><head><script language=\"javascript\" type=\"text/javascript\"> function getHeight() { var theHeight = document.getElementById(\"heightProvider\").offsetHeight; return theHeight;} </script></head><body><div id=\"heightProvider\">" + ListItemData.body[".data"] + "</div></body></html>"
+                html: "<html><body>" + ListItemData.body[".data"] + "</body></html>"
                 settings.zoomToFitEnabled: false
                 settings.background: Color.Transparent
                 settings.viewport: { "initial-scale" : 1.0, "width" : "device-width"}
@@ -105,19 +103,6 @@ CustomListItem {
                     }
                 }
                 
-                //Get the height of the forum content after it's loaded.
-                onLoadingChanged: {
-                    if (loadRequest.status == WebLoadStatus.Succeeded) {
-                        bodyWebView.evaluateJavaScript("getHeight();", JavaScriptWorld.Normal);
-                    }
-                }
-                
-                //Reset the CustomListItem's height based on the post content.
-                //Take ScrollView scale into consideration so we don't have extra white space.
-                //ScrollView will zoom out for wide content.
-                onJavaScriptResult: {
-                    forumThreadItem.preferredHeight = 380 + (result * bodyWebView.settings.devicePixelRatio);
-                }
                 settings.webInspectorEnabled: false
             
             }

--- a/Community3/assets/items/ForumThreadListItem.qml
+++ b/Community3/assets/items/ForumThreadListItem.qml
@@ -22,7 +22,6 @@ import bb.cascades 1.2
 //CustomListItem for displaying Threads.
 
 CustomListItem {
-    preferredHeight: 265 
     dividerVisible: true
     highlightAppearance: HighlightAppearance.Frame
     Container {

--- a/Community3/assets/items/ForumThreadSearchListItem.qml
+++ b/Community3/assets/items/ForumThreadSearchListItem.qml
@@ -23,7 +23,6 @@ import com.msohm.BoardProperties 1.0
 //CustomListItem for displaying Search Result Threads.
 
 CustomListItem {
-    preferredHeight: 265 
     dividerVisible: true
     highlightAppearance: HighlightAppearance.Frame
     Container {

--- a/Community3/assets/items/ForumThreadSolutionItem.qml
+++ b/Community3/assets/items/ForumThreadSolutionItem.qml
@@ -22,8 +22,6 @@ import com.msohm.URLProvider 1.0
 
 CustomListItem {
     id: forumThreadItem
-    preferredHeight: 5000 //Set to a large number which should accomodate most posts.  It's shrunk after the post content size is calculated.
-    preferredWidth: 5000 //Large number so wide posts fit in the WebView.
     dividerVisible: true
     highlightAppearance: HighlightAppearance.Frame
 	    
@@ -98,7 +96,7 @@ CustomListItem {
 	            WebView {
 	                id: bodyWebView
 	                //This allows for horizontal scrolling with the content zoomed to the desired level.
-                    html: "<html><head><script language=\"javascript\" type=\"text/javascript\"> function getHeight() { var theHeight = document.getElementById(\"heightProvider\").offsetHeight; return theHeight;} </script></head><body><div id=\"heightProvider\">" + ListItemData.body[".data"] + "</div></body></html>"
+                    html: "<html><body>" + ListItemData.body[".data"] + "</body></html>"
                     settings.zoomToFitEnabled: false
 	                settings.background: Color.Transparent
                     settings.viewport: { "initial-scale" : 1.0, "width" : "device-width"}
@@ -114,19 +112,6 @@ CustomListItem {
 	                    }
 	                }
 	
-	                //Get the height of the forum content after it's loaded.
-	                onLoadingChanged: {
-	                    if (loadRequest.status == WebLoadStatus.Succeeded) {
-	                        bodyWebView.evaluateJavaScript("getHeight();", JavaScriptWorld.Normal);
-	                    }
-	                }
-	
-	                //Reset the CustomListItem's height based on the post content.
-	                //Take ScrollView scale into consideration so we don't have extra white space.
-	                //ScrollView will zoom out for wide content.
-	                onJavaScriptResult: {
-                        forumThreadItem.preferredHeight = 380 + (result * bodyWebView.settings.devicePixelRatio);
-	                }
 	                settings.webInspectorEnabled: false
 	
 	            }


### PR DESCRIPTION
Removed workaround requiring manual height calculation of CustomListItem that was required prior to BlackBerry 10 OS 10.3.1.
